### PR TITLE
Add license to gemspec

### DIFF
--- a/debug_inspector.gemspec
+++ b/debug_inspector.gemspec
@@ -12,4 +12,5 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.platform = Gem::Platform::RUBY
   s.extensions = ["ext/debug_inspector/extconf.rb"]
+  s.license = 'MIT'
 end


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.