### PR TITLE
Add Travis build status to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-debug_inspector
+debug_inspector [![Build Status](https://travis-ci.org/banister/debug_inspector.svg?branch=master)](https://travis-ci.org/banister/debug_inspector)
 ===============
 
 _A Ruby wrapper for the new MRI 2.0 debug\_inspector API_


### PR DESCRIPTION
@banister I added Travis build status for HEAD of master branch to `READMD.md`.
This is good to see easily current build status.

You can check it on my branch.
https://github.com/junaruga/debug_inspector/tree/feature/travis-build-status

As you may know, this is typical way to see it.
You can see other examples here.
https://github.com/junaruga/rspec-core
https://github.com/rack/rack
