### PR TITLE
fix minitest dependency

### DIFF
--- a/debug_inspector.gemspec
+++ b/debug_inspector.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.extensions = ["ext/debug_inspector/extconf.rb"]
   s.license = 'MIT'
-  s.add_development_dependency 'minitest', '>= 5'
+  s.add_development_dependency 'minitest', '~> 5.10'
 end


### PR DESCRIPTION
Minitest 6 won't be backwards compatible. Minitest 7 won't be compatible with
Minitest 6, etc. To be sure the tests keep running throughout the rest of time,
specify a version requirement that won't break API compatibility.