### PR TITLE
Fix gem installation and load in non-MRI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,8 @@ jobs:
     - name: Test
       run: bundle exec rake
 
-  installation:
-    name: "Installation"
+  system:
+    name: "System"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -86,3 +86,13 @@ jobs:
 
     - name: Install gem
       run: bundle exec rake install
+
+    - name: Create directory for gem test
+      run: mkdir -p tmp/gem-test
+
+    - name: Create test Gemfile
+      run: echo "gem 'debug_inspector'" > Gemfile
+      working-directory: ./tmp/gem-test
+
+    - name: Test gem
+      run: bundle exec ruby -e "require 'debug_inspector'; RubyVM::DebugInspector.open { |dc| dc.frame_binding(1) }"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,21 +29,29 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
-          - "head"
-        exclude:
-          # Windows doesn't have 3.0, so run head there but nowhere else.
-          - { ruby: "head", os: "macos-latest" }
-          - { ruby: "head", os: "ubuntu-latest" }
-          - { ruby: "3.0", os: "windows-latest" }
 
     steps:
 
     - uses: actions/checkout@v2
 
+    - name: Determine ruby version name
+      id: ruby_version
+      run: |
+        if [[ $OS == 'windows-latest' && $RUBY == '3.0' ]]; then
+          # Windows doesn't have 3.0, so run head there but nowhere else.
+          echo "::set-output name=release::head"
+        else
+          echo "::set-output name=release::$RUBY"
+        fi
+      shell: bash
+      env:
+        OS: ${{ matrix.os }}
+        RUBY: ${{ matrix.ruby }}
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}
+        ruby-version: ${{ steps.ruby_version.outputs.release }}
         bundler-cache: true
 
     - name: Test
@@ -62,14 +70,9 @@ jobs:
         ruby:
           - "2"
           - "3.0"
-          - "head"
           - "jruby"
           - "truffleruby"
         exclude:
-          # Windows doesn't have 3.0, so run head there but nowhere else.
-          - { ruby: "head", os: "macos-latest" }
-          - { ruby: "head", os: "ubuntu-latest" }
-          - { ruby: "3.0", os: "windows-latest" }
           # Windows releases of jruby and truffleruby have issues. Skip them for now.
           - { ruby: "jruby", os: "windows-latest" }
           - { ruby: "truffleruby", os: "windows-latest" }
@@ -78,10 +81,24 @@ jobs:
 
     - uses: actions/checkout@v2
 
+    - name: Determine ruby version name
+      id: ruby_version
+      run: |
+        if [[ $OS == 'windows-latest' && $RUBY == '3.0' ]]; then
+          # Windows doesn't have 3.0, so run head there but nowhere else.
+          echo "::set-output name=release::head"
+        else
+          echo "::set-output name=release::$RUBY"
+        fi
+      shell: bash
+      env:
+        OS: ${{ matrix.os }}
+        RUBY: ${{ matrix.ruby }}
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}
+        ruby-version: ${{ steps.ruby_version.outputs.release }}
         bundler-cache: true
 
     - name: Install gem

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,13 +28,13 @@ jobs:
           - "2.5"
           - "2.6"
           - "2.7"
-          - "3.0.0-preview2"
+          - "3.0"
           - "head"
         exclude:
-          # Windows doesn't have 3.0 previews, so run head there but nowhere else
+          # Windows doesn't have 3.0, so run head there but nowhere else.
           - { ruby: "head", os: "macos-latest" }
           - { ruby: "head", os: "ubuntu-latest" }
-          - { ruby: "3.0.0-preview2", os: "windows-latest" }
+          - { ruby: "3.0", os: "windows-latest" }
 
     steps:
 
@@ -61,9 +61,18 @@ jobs:
           - windows-latest
         ruby:
           - "2"
+          - "3.0"
           - "head"
           - "jruby"
           - "truffleruby"
+        exclude:
+          # Windows doesn't have 3.0, so run head there but nowhere else.
+          - { ruby: "head", os: "macos-latest" }
+          - { ruby: "head", os: "ubuntu-latest" }
+          - { ruby: "3.0", os: "windows-latest" }
+          # Windows releases of jruby and truffleruby have issues. Skip them for now.
+          - { ruby: "jruby", os: "windows-latest" }
+          - { ruby: "truffleruby", os: "windows-latest" }
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   test:
+    name: "Unit"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -47,3 +48,32 @@ jobs:
 
     - name: Test
       run: bundle exec rake
+
+  installation:
+    name: "Installation"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        ruby:
+          - "2"
+          - "head"
+          - "jruby"
+          - "truffleruby"
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+
+    - name: Install gem
+      run: bundle exec rake install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,5 +94,9 @@ jobs:
       run: echo "gem 'debug_inspector'" > Gemfile
       working-directory: ./tmp/gem-test
 
-    - name: Test gem
+    - name: Test gem load
+      run: bundle exec ruby -e "require 'debug_inspector'"
+
+    - name: Test gem functionality
+      if: ${{ matrix.ruby != 'jruby' && matrix.ruby != 'truffleruby' }}
       run: bundle exec ruby -e "require 'debug_inspector'; RubyVM::DebugInspector.open { |dc| dc.frame_binding(1) }"

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,10 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
+def can_compile_extensions?
+  RUBY_ENGINE == "ruby"
+end 
+
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
@@ -11,10 +15,13 @@ end
 
 require "rake/extensiontask"
 
-task :build => :compile
+if can_compile_extensions?
+  task :build => :compile
+  task :default => [:clobber, :compile, :test]
+else
+  task :default => [:test]
+end
 
 Rake::ExtensionTask.new("debug_inspector") do |ext|
   ext.lib_dir = "lib"
 end
-
-task :default => [:clobber, :compile, :test]

--- a/debug_inspector.gemspec
+++ b/debug_inspector.gemspec
@@ -1,8 +1,8 @@
-require_relative "lib/rubyvm/debug_inspector/version"
+# We don't want to define any constants if the gem extension isn't loaded, so not requiring the version file.
 
 Gem::Specification.new do |spec|
   spec.name          = "debug_inspector"
-  spec.version       = RubyVM::DebugInspector::VERSION
+  spec.version       = "0.0.3"
   spec.authors       = ["John Mair (banisterfiend)"]
   spec.email         = ["jrmair@gmail.com"]
 

--- a/debug_inspector.gemspec
+++ b/debug_inspector.gemspec
@@ -21,5 +21,8 @@ Gem::Specification.new do |spec|
   end
 
   spec.require_paths = ["lib"]
-  spec.extensions    = ["ext/debug_inspector/extconf.rb"]
+
+  if RUBY_ENGINE == "ruby"
+    spec.extensions = ["ext/debug_inspector/extconf.rb"]
+  end
 end

--- a/ext/debug_inspector/extconf.rb
+++ b/ext/debug_inspector/extconf.rb
@@ -1,6 +1,8 @@
 def fake_makefile
-  File.open(File.join(File.dirname(__FILE__), "Makefile"), "w") {|f|
-    f.puts %[install:\n\techo "This Ruby not supported by/does not require debug_inspector.\n"]
+  File.open("Makefile", "w") { |f|
+    f.puts '.PHONY: install'
+    f.puts 'install:'
+    f.puts "\t" + '@echo "This Ruby not supported by/does not require debug_inspector."'
   }
 end
 

--- a/lib/rubyvm/debug_inspector/version.rb
+++ b/lib/rubyvm/debug_inspector/version.rb
@@ -1,3 +1,4 @@
 class RubyVM::DebugInspector
+  # Don't forget to update the version string in the gemspec file.
   VERSION = "0.0.3"
 end


### PR DESCRIPTION
This allows the gem to install on a non-MRI platform, which I broke in #23.

The fake makefile was being generated in the wrong location, since the new rake tasks use a `tmp` directory to do their build. Luckily they set the working directory, so it's an easy change. I changed the fake output based on [this SO answer](https://stackoverflow.com/a/17653625/1589422).

So to make sure this is covered in the future, I added a CI job that installs the gem on various platforms.

Also removed the inclusion of `version.rb` in the gemspec, which in retrospect was obviously left out for a good reason. I added some comments to make it clear for the future.