### PR TITLE
Load extension from ext directory when it's not in lib

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,9 @@ jobs:
       run: echo "gem 'debug_inspector'" > Gemfile
       working-directory: ./tmp/gem-test
 
+    - name: List gem contents
+      run: find $(bundle show debug_inspector)
+
     - name: Test gem load
       run: bundle exec ruby -e "require 'debug_inspector'"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,9 @@ jobs:
         bundler-cache: true
 
     - name: Install gem
-      run: bundle exec rake install
+      run: |
+        bundle exec gem build debug_inspector.gemspec
+        gem install debug_inspector*.gem
 
     - name: Create directory for gem test
       run: mkdir -p tmp/gem-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ruby:
+          # This includes rubies that are not actually extended by this gem.
+          # We want to make sure the gem silently fails to load on those platforms.
           - "2"
           - "3.0"
           - "jruby"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,24 +34,10 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Determine ruby version name
-      id: ruby_version
-      run: |
-        if [[ $OS == 'windows-latest' && $RUBY == '3.0' ]]; then
-          # Windows doesn't have 3.0, so run head there but nowhere else.
-          echo "::set-output name=release::head"
-        else
-          echo "::set-output name=release::$RUBY"
-        fi
-      shell: bash
-      env:
-        OS: ${{ matrix.os }}
-        RUBY: ${{ matrix.ruby }}
-
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ steps.ruby_version.outputs.release }}
+        ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
 
     - name: Test
@@ -81,24 +67,10 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Determine ruby version name
-      id: ruby_version
-      run: |
-        if [[ $OS == 'windows-latest' && $RUBY == '3.0' ]]; then
-          # Windows doesn't have 3.0, so run head there but nowhere else.
-          echo "::set-output name=release::head"
-        else
-          echo "::set-output name=release::$RUBY"
-        fi
-      shell: bash
-      env:
-        OS: ${{ matrix.os }}
-        RUBY: ${{ matrix.ruby }}
-
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ steps.ruby_version.outputs.release }}
+        ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
 
     - name: Install gem

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,10 +75,11 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
 
+    - name: Build gem
+      run: bundle exec gem build --verbose debug_inspector.gemspec
+
     - name: Install gem
-      run: |
-        bundle exec gem build debug_inspector.gemspec
-        gem install debug_inspector*.gem
+      run: gem install --verbose debug_inspector*.gem
 
     - name: Create directory for gem test
       run: mkdir -p tmp/gem-test
@@ -87,12 +88,25 @@ jobs:
       run: echo "gem 'debug_inspector'" > Gemfile
       working-directory: ./tmp/gem-test
 
-    - name: List gem contents
-      run: find $(bundle show debug_inspector)
+    - name: Get gem installation path
+      id: gem_path
+      run: |
+        gem_path=$(bundle show debug_inspector)
+        echo "gem_path is ${gem_path}"
+        echo "::set-output name=path::${gem_path}"
+      shell: bash
+      working-directory: ./tmp/gem-test
+
+    - name: List installed gem contents
+      run: find .
+      shell: bash
+      working-directory: ${{ steps.gem_path.outputs.path }}
 
     - name: Test gem load
       run: bundle exec ruby -e "require 'debug_inspector'"
+      working-directory: ./tmp/gem-test
 
     - name: Test gem functionality
       if: ${{ matrix.ruby != 'jruby' && matrix.ruby != 'truffleruby' }}
       run: bundle exec ruby -e "require 'debug_inspector'; RubyVM::DebugInspector.open { |dc| dc.frame_binding(1) }"
+      working-directory: ./tmp/gem-test

--- a/Rakefile
+++ b/Rakefile
@@ -22,4 +22,6 @@ else
   task :default => [:test]
 end
 
-Rake::ExtensionTask.new("debug_inspector")
+Rake::ExtensionTask.new("debug_inspector") do |ext|
+  ext.lib_dir = "lib"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,4 @@ else
   task :default => [:test]
 end
 
-Rake::ExtensionTask.new("debug_inspector") do |ext|
-  ext.lib_dir = "lib"
-end
+Rake::ExtensionTask.new("debug_inspector")

--- a/lib/debug_inspector.rb
+++ b/lib/debug_inspector.rb
@@ -1,8 +1,9 @@
 require 'rbconfig'
 dlext = RbConfig::CONFIG['DLEXT']
 begin
-  require_relative "debug_inspector.#{dlext}"
+  require_relative "../ext/debug_inspector/debug_inspector.#{dlext}"
   # If the above require fails, we don't want to define any constants.
   require_relative "rubyvm/debug_inspector/version"
-rescue LoadError
+rescue LoadError => e
+  puts "debug_inspector extension was not loaded"
 end

--- a/lib/debug_inspector.rb
+++ b/lib/debug_inspector.rb
@@ -1,9 +1,17 @@
 require 'rbconfig'
 dlext = RbConfig::CONFIG['DLEXT']
 begin
-  require_relative "../ext/debug_inspector/debug_inspector.#{dlext}"
-  # If the above require fails, we don't want to define any constants.
+  # If the installation task did its job, the extension is in lib/ next to this file.
+  require "debug_inspector.#{dlext}"
+  # We only want to define constants if the extension has loaded.
   require_relative "rubyvm/debug_inspector/version"
-rescue LoadError => e
-  puts "debug_inspector extension was not loaded"
+rescue LoadError
+  begin
+    # If not, maybe the extension is in ext/
+    require_relative "../ext/debug_inspector/debug_inspector.#{dlext}"
+    # We only want to define constants if the extension has loaded.
+    require_relative "rubyvm/debug_inspector/version"
+  rescue LoadError => e
+    puts "debug_inspector extension was not loaded"
+  end
 end


### PR DESCRIPTION
In some environments the built extension library file isn't copied into lib/, so the gem is unable to load the extension.

https://github.com/tootsuite/mastodon/issues/15863
Fixes #29

In cases where the build process worked correctly, the extension binary was stored in `lib/` within the installed gem. In cases where it was not working, the extension library was located in `ext/`.

Note that the way it previously worked is as prescribed in the [rubygems documentation](https://guides.rubygems.org/gems-with-extensions/) and [the rake-compiler](https://github.com/rake-compiler/rake-compiler) readme. Using a relative path to dig back up into the `ext/` directory should work, but it's strange that this is necessary.
