### PR TITLE
Rename RubyVM::DebugInspector to DebugInspector and add support for truffleruby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,17 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+          - "3.1"
+          - "3.2"
+          - "truffleruby"
         exclude:
           # 2.2 segfaults on recent Ubuntu: https://github.com/ruby/setup-ruby/issues/496
           - { ruby: "2.2", os: "ubuntu-latest" }
+          # TruffleRuby does not support Windows.
+          - { ruby: "truffleruby", os: "windows-latest" }
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -63,13 +68,14 @@ jobs:
           - "jruby"
           - "truffleruby"
         exclude:
-          # Windows releases of jruby and truffleruby have issues. Skip them for now.
+          # Windows releases of jruby have issues. Skip them for now.
           - { ruby: "jruby", os: "windows-latest" }
+          # TruffleRuby does not support Windows.
           - { ruby: "truffleruby", os: "windows-latest" }
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -109,6 +115,6 @@ jobs:
       working-directory: ./tmp/gem-test
 
     - name: Test gem functionality
-      if: ${{ matrix.ruby != 'jruby' && matrix.ruby != 'truffleruby' }}
-      run: bundle exec ruby -e "require 'debug_inspector'; RubyVM::DebugInspector.open { |dc| dc.frame_binding(1) }"
+      if: ${{ matrix.ruby != 'jruby' }}
+      run: bundle exec ruby -e "require 'debug_inspector'; DebugInspector.open { |dc| dc.frame_binding(1) }"
       working-directory: ./tmp/gem-test

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ require 'debug_inspector'
 
 # Open debug context
 # Passed `dc' is only active in a block
-RubyVM::DebugInspector.open { |dc|
+DebugInspector.open { |dc|
   # backtrace locations (returns an array of Thread::Backtrace::Location objects)
   locs = dc.backtrace_locations
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,8 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 
 def can_compile_extensions?
-  RUBY_ENGINE == "ruby"
-end 
+  RUBY_ENGINE == "ruby" or RUBY_ENGINE == "truffleruby"
+end
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"

--- a/debug_inspector.gemspec
+++ b/debug_inspector.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{A Ruby wrapper for the MRI 2.0 debug_inspector API}
   spec.description   = <<-TXT
-Adds methods to RubyVM::DebugInspector to allow for inspection of backtrace frames.
+Adds methods to DebugInspector to allow for inspection of backtrace frames.
 
 The debug_inspector C extension and API were designed and built by Koichi Sasada, this project is just a gemification of his work.
 
@@ -31,7 +31,5 @@ TXT
 
   spec.require_paths = ["lib"]
 
-  if RUBY_ENGINE == "ruby"
-    spec.extensions = ["ext/debug_inspector/extconf.rb"]
-  end
+  spec.extensions = ["ext/debug_inspector/extconf.rb"]
 end

--- a/ext/debug_inspector/debug_inspector.c
+++ b/ext/debug_inspector/debug_inspector.c
@@ -104,8 +104,7 @@ di_open_s(VALUE klass)
 void
 Init_debug_inspector(void)
 {
-    VALUE rb_cRubyVM = rb_const_get(rb_cObject, rb_intern("RubyVM"));
-    VALUE cDebugInspector = rb_define_class_under(rb_cRubyVM, "DebugInspector", rb_cObject);
+    VALUE cDebugInspector = rb_define_class("DebugInspector", rb_cObject);
     
     rb_undef_alloc_func(cDebugInspector);
     rb_define_singleton_method(cDebugInspector, "open", di_open_s, 0);

--- a/ext/debug_inspector/extconf.rb
+++ b/ext/debug_inspector/extconf.rb
@@ -6,12 +6,11 @@ def fake_makefile
   }
 end
 
-def mri_2_or_3?
-  defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" &&
-    RUBY_VERSION =~ /^[23]/
+def can_compile_extensions?
+  RUBY_ENGINE == "ruby" or RUBY_ENGINE == "truffleruby"
 end
 
-if mri_2_or_3?
+if can_compile_extensions?
   require 'mkmf'
   create_makefile('debug_inspector')
 else

--- a/lib/debug_inspector.rb
+++ b/lib/debug_inspector.rb
@@ -4,14 +4,21 @@ begin
   # If the installation task did its job, the extension is in lib/ next to this file.
   require "debug_inspector.#{dlext}"
   # We only want to define constants if the extension has loaded.
-  require_relative "rubyvm/debug_inspector/version"
+  require_relative "debug_inspector/version"
 rescue LoadError
   begin
     # If not, maybe the extension is in ext/
     require_relative "../ext/debug_inspector/debug_inspector.#{dlext}"
     # We only want to define constants if the extension has loaded.
-    require_relative "rubyvm/debug_inspector/version"
+    require_relative "debug_inspector/version"
   rescue LoadError => e
-    puts "debug_inspector extension was not loaded"
+    puts "debug_inspector extension was not loaded (#{e})"
+  end
+end
+
+if defined?(RubyVM) && defined?(DebugInspector)
+  RubyVM::DebugInspector = DebugInspector
+  if RubyVM.respond_to?(:deprecate_constant)
+    RubyVM.deprecate_constant :DebugInspector
   end
 end

--- a/lib/debug_inspector/version.rb
+++ b/lib/debug_inspector/version.rb
@@ -1,4 +1,4 @@
-class RubyVM::DebugInspector
+class DebugInspector
   # Don't forget to update the version string in the gemspec file.
   VERSION = "1.1.0"
 end

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -1,33 +1,59 @@
 require "test_helper"
 
 class BasicTest < Minitest::Test
+  def setup
+    @offset = DebugInspector.open do |dc|
+      dc.backtrace_locations.index { |loc| loc.path == __FILE__ and loc.label == "setup" }
+    end
+  end
+
   def test_version
-    assert(RubyVM::DebugInspector::VERSION)
+    assert(DebugInspector::VERSION)
+  end
+
+  def test_legacy_name
+    if RUBY_ENGINE == "ruby"
+      if RubyVM.respond_to?(:deprecate_constant)
+        warning = /warning: constant RubyVM::DebugInspector is deprecated/
+      else
+        warning = ''
+      end
+
+      assert_output('', warning) do
+        assert_same DebugInspector, RubyVM::DebugInspector
+      end
+    else
+      assert !defined?(RubyVM::DebugInspector)
+    end
   end
 
   def test_backtrace_locations
-    RubyVM::DebugInspector.open do |dc|
+    DebugInspector.open do |dc|
       assert dc.backtrace_locations.size > 0
       dc.backtrace_locations.each{|e| assert_instance_of Thread::Backtrace::Location, e}
     end
   end
 
   def test_frame_binding
-    RubyVM::DebugInspector.open do |dc|
-      assert_equal self, dc.frame_binding(1).eval("self")
-      assert_equal __method__, dc.frame_binding(1).eval("__method__")
+    DebugInspector.open do |dc|
+      assert_equal self, dc.frame_binding(@offset).eval("self")
+      assert_equal __method__, dc.frame_binding(@offset).eval("__method__")
     end
   end
 
   def test_frame_class
-    RubyVM::DebugInspector.open do |dc|
-      assert_equal self.class, dc.frame_class(1)
+    DebugInspector.open do |dc|
+      assert_equal self.class, dc.frame_class(@offset)
     end
   end
 
   def test_frame_iseq
-    RubyVM::DebugInspector.open do |dc|
-      assert_equal __FILE__, dc.frame_iseq(1).path
+    DebugInspector.open do |dc|
+      if RUBY_ENGINE == "ruby"
+        assert_equal __FILE__, dc.frame_iseq(@offset).path
+      else
+        assert_nil dc.frame_iseq(@offset)
+      end
     end
   end
 end


### PR DESCRIPTION
* Fixes https://github.com/banister/debug_inspector/issues/36
* Also update CI.